### PR TITLE
feat: add new alternative for redshift connection creation

### DIFF
--- a/awswrangler/redshift.py
+++ b/awswrangler/redshift.py
@@ -313,6 +313,7 @@ def connect(
     connection: Optional[str] = None,
     secret_id: Optional[str] = None,
     catalog_id: Optional[str] = None,
+    connection_details: Optional[Dict[str, str]] = None,
     dbname: Optional[str] = None,
     boto3_session: Optional[boto3.Session] = None,
     ssl: bool = True,
@@ -387,7 +388,8 @@ def connect(
 
     """
     attrs: _db_utils.ConnectionAttributes = _db_utils.get_connection_attributes(
-        connection=connection, secret_id=secret_id, catalog_id=catalog_id, dbname=dbname, boto3_session=boto3_session
+        connection=connection, secret_id=secret_id, catalog_id=catalog_id, dbname=dbname, boto3_session=boto3_session,
+        connection_details=connection_details
     )
     if attrs.kind != "redshift":
         raise exceptions.InvalidDatabaseType(


### PR DESCRIPTION
***Description of changes:***

Currently, the `awswrangler.redshift.connect` method only accepts a `secret id arn` or a Glue connection, this affects the implementation of other secret management tools/techniques.

To allow the injection of a key-value map which describes the connection for a redshift instance a new method has been added and original methods were adapted to accept this new option.

***How to use it:***

```python
>>> import awswrangler as wr
>>> 
>>> details = {}
>>> details["user"] = "<username>"
>>> details["pass"] = "<password>"
>>> details["host"] = "<host>"
>>> details["port"] = "<port>"
>>> details["dbname"] = "<db name>"
>>> details["kind"] = "redshift"
>>> 
>>> connection = wr.redshift.connect(connection_details=details)
>>> connection
<redshift_connector.core.Connection object at 0x1050c25e0>
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
